### PR TITLE
AppOps: fix wifi scan op

### DIFF
--- a/core/java/android/app/AppOpsManager.java
+++ b/core/java/android/app/AppOpsManager.java
@@ -247,7 +247,7 @@ public class AppOpsManager {
             OP_WRITE_CALL_LOG,
             OP_READ_CALENDAR,
             OP_WRITE_CALENDAR,
-            OP_COARSE_LOCATION,
+            OP_WIFI_SCAN,
             OP_POST_NOTIFICATION,
             OP_COARSE_LOCATION,
             OP_CALL_PHONE,
@@ -424,7 +424,7 @@ public class AppOpsManager {
             android.Manifest.permission.WRITE_CALL_LOG,
             android.Manifest.permission.READ_CALENDAR,
             android.Manifest.permission.WRITE_CALENDAR,
-            android.Manifest.permission.ACCESS_WIFI_STATE,
+            null, // no permission for wifi scan available
             null, // no permission required for notifications
             null, // neighboring cells shares the coarse location perm
             android.Manifest.permission.CALL_PHONE,


### PR DESCRIPTION
There's no direct permission tied to it and fix the op-to-switch entry.

Change-Id: I661ef6707ba50adb371e3223a91880c4838df669
Signed-off-by: Roman Birg roman@cyngn.com
(cherry picked from commit 72a1fbe5f76ef6c5e6fb9cd56d4bd1aee940303b)
